### PR TITLE
Sprint 2 Dev Work from May 4 - 5

### DIFF
--- a/sites/all/modules/custom/slac_search/slac_search.module
+++ b/sites/all/modules/custom/slac_search/slac_search.module
@@ -160,6 +160,19 @@ function slac_search_theme() {
 }
 
 /**
+ * Implements hook_form_alter().
+ *
+ * Adds taxonomy term autocomplete for the Tags vocabulary to the search form.
+ */
+function slac_search_form_alter(&$form, &$form_state, $form_id) {
+  if ($form_id == 'views_exposed_form') {
+    if ($form['#id'] == 'views-exposed-form-search-page') {
+      $form['secondary']['field_shared_tags_name']['#autocomplete_path'] = 'taxonomy/autocomplete/field_shared_tags';
+    }
+  }
+}
+
+/**
  * Process variables for slac-search-block-form.tpl.php.
  *
  * The $variables array contains the following arguments:


### PR DESCRIPTION
## Deployment instructions

Run the following commands being sure to add your site alias after `drush`.

`drush updb -y`
`drush fra -y`
`drush cc all`
`drush fl`
If the features are still overridden run `drush fra` again.
### Ready for QA
- [Sprint 2 - Bug - Search Find content tagged as should be autocomplete](https://project.mediacurrent.com/slactoday/node/61287#comment-844482)
